### PR TITLE
feat(payments): rotate ready receiving methods before stepping order amounts

### DIFF
--- a/src/features/orders/server/create.ts
+++ b/src/features/orders/server/create.ts
@@ -116,16 +116,20 @@ async function createOrderRecord(
 		)
 		.bind(input.paymentAsset, input.paymentNetwork)
 		.all<{ id: string }>();
+	const readyMethodIds: string[] = [];
 	for (const method of methods.results) {
 		const readiness = await checkReceivingMethodReadiness(db, method.id);
-		if (readiness.ready)
-			return createOrderFromReceivingMethod(
-				db,
-				{ ...input, receivingMethodId: method.id },
-				requestUrl,
-				context,
-			);
+		if (readiness.ready) readyMethodIds.push(method.id);
 	}
+	const [firstMethodId, ...fallbackMethodIds] = readyMethodIds;
+	if (firstMethodId)
+		return createOrderFromReceivingMethod(
+			db,
+			{ ...input, receivingMethodId: firstMethodId },
+			requestUrl,
+			context,
+			fallbackMethodIds,
+		);
 	if (methods.results.length === 0)
 		throw new OrderServiceError(
 			"receiving_method_not_found",
@@ -144,6 +148,7 @@ async function createOrderFromReceivingMethod(
 	input: CreateOrderInput,
 	requestUrl: string,
 	context: OrderCreationContext = {},
+	fallbackMethodIds: string[] = [],
 ): Promise<ApiOrder> {
 	const methodId = input.receivingMethodId;
 	if (!methodId) throw new Error("Receiving method is required");
@@ -200,6 +205,30 @@ async function createOrderFromReceivingMethod(
 		paymentAsset: method.code,
 		paymentNetwork: method.rail_code,
 	};
+	const fallbackRows =
+		fallbackMethodIds.length === 0
+			? []
+			: (
+					await db
+						.prepare(
+							`SELECT rm.id, rm.target_value, rm.min_amount_minor, rm.max_amount_minor,
+							 pa.id AS payment_method_id
+							 FROM receiving_methods rm
+							 JOIN receiving_method_assets link ON link.receiving_method_id = rm.id
+							 JOIN payment_assets pa ON pa.id = link.payment_asset_id
+							 WHERE rm.id IN (${fallbackMethodIds.map(() => "?").join(", ")})
+							 AND pa.code = ? AND pa.rail_code = ?
+							 ORDER BY rm.sort_order, rm.created_at, rm.id`,
+						)
+						.bind(...fallbackMethodIds, method.code, method.rail_code)
+						.all<{
+							id: string;
+							target_value: string;
+							min_amount_minor: string | null;
+							max_amount_minor: string | null;
+							payment_method_id: string;
+						}>()
+				).results;
 	const exchangeRateQuote = await quoteWithExchangeRate(db, {
 		amount: input.amount,
 		currency: input.currency,
@@ -214,13 +243,16 @@ async function createOrderFromReceivingMethod(
 		method.decimals,
 		"up",
 	).toString();
-	const orderAmountUsdMinor =
-		method.min_amount_minor !== null || method.max_amount_minor !== null
-			? await quoteUsdAmountMinor(db, {
-					amount: input.amount,
-					currency: input.currency,
-				})
-			: null;
+	const orderAmountUsdMinor = [method, ...fallbackRows].some(
+		(candidate) =>
+			candidate.min_amount_minor !== null ||
+			candidate.max_amount_minor !== null,
+	)
+		? await quoteUsdAmountMinor(db, {
+				amount: input.amount,
+				currency: input.currency,
+			})
+		: null;
 	const settings = await loadOperationalSettings(db);
 	const expiresInMs = resolveOrderExpiryMs(input.expiresInMs, settings);
 	const now = Date.now();
@@ -228,6 +260,8 @@ async function createOrderFromReceivingMethod(
 	const fiatDecimals = currencyDecimals(input.currency);
 	const amountMinor = decimalToMinor(input.amount, fiatDecimals).toString();
 	const orderId = generateOrderId();
+	let allocatedMethodId = methodId;
+	let allocatedTarget = method.target_value;
 	try {
 		const allocation = await allocateUniqueReceivingMethodAndSnapshot(db, {
 			orderId,
@@ -235,6 +269,14 @@ async function createOrderFromReceivingMethod(
 			paymentMethodId: method.payment_method_id,
 			expectedAmountUnits,
 			...(orderAmountUsdMinor ? { orderAmountUsdMinor } : {}),
+			...(fallbackRows.length
+				? {
+						fallbackMethods: fallbackRows.map((row) => ({
+							receivingMethodId: row.id,
+							paymentMethodId: row.payment_method_id,
+						})),
+					}
+				: {}),
 			decimals: method.decimals,
 			expiresAt,
 			reusableAt: settings.immediateReleaseMode
@@ -267,6 +309,13 @@ async function createOrderFromReceivingMethod(
 			},
 		});
 		paymentAmount = allocation.paymentAmount;
+		const fallback = fallbackRows.find(
+			(row) => row.id === allocation.receivingMethodId,
+		);
+		if (fallback) {
+			allocatedMethodId = fallback.id;
+			allocatedTarget = fallback.target_value;
+		}
 	} catch (error) {
 		if (error instanceof PaymentOrderConflictError)
 			throw new OrderServiceError(
@@ -291,8 +340,8 @@ async function createOrderFromReceivingMethod(
 		paymentAmount,
 		paymentAsset: method.code,
 		paymentNetwork: method.rail_code,
-		receivingMethodId: methodId,
-		receiveAddress: method.target_value,
+		receivingMethodId: allocatedMethodId,
+		receiveAddress: allocatedTarget,
 		checkoutUrl: `${new URL(requestUrl).origin}/checkout/${orderId}`,
 		expiresAt: new Date(expiresAt).toISOString(),
 		...(input.notifyUrl ? { notifyUrl: input.notifyUrl } : {}),

--- a/src/features/payment-settings/server/receiving-method-locks.ts
+++ b/src/features/payment-settings/server/receiving-method-locks.ts
@@ -57,6 +57,10 @@ export async function allocateUniqueReceivingMethodAndSnapshot(
 	input: PaymentAllocationInput & {
 		decimals: number;
 		maximumAttempts?: number;
+		fallbackMethods?: Array<{
+			receivingMethodId: string;
+			paymentMethodId: string;
+		}>;
 	},
 ) {
 	const configuredDecimals = await loadCheckoutAmountDecimals(db);
@@ -72,28 +76,43 @@ export async function allocateUniqueReceivingMethodAndSnapshot(
 	const {
 		decimals,
 		maximumAttempts: _maximumAttempts,
+		fallbackMethods,
 		...allocationInput
 	} = input;
+	// Every candidate is tried at the requested amount before the amount is
+	// stepped up, so concurrent equal-amount orders spread across methods first.
+	const candidates = [
+		{
+			receivingMethodId: input.receivingMethodId,
+			paymentMethodId: input.paymentMethodId,
+		},
+		...(fallbackMethods ?? []),
+	];
 	for (let offset = 0; offset < maximumAttempts; offset++) {
 		const amountUnits =
 			quantized.amountUnits + BigInt(offset) * quantized.stepUnits;
 		const expectedAmountUnits = amountUnits.toString();
 		const paymentAmount = unitsToDecimal(amountUnits, decimals);
-		try {
-			const allocated = await allocateReceivingMethodAndSnapshot(db, {
-				...allocationInput,
-				expectedAmountUnits,
-				...(input.order ? { order: input.order } : {}),
-				...(input.existingOrder ? { existingOrder: input.existingOrder } : {}),
-			});
-			return { ...allocated, expectedAmountUnits, paymentAmount };
-		} catch (error) {
-			if (
-				!(error instanceof ReceivingMethodUnavailableError) ||
-				error.reason !== "collision" ||
-				offset === maximumAttempts - 1
-			)
-				throw error;
+		for (const candidate of [...candidates]) {
+			try {
+				const allocated = await allocateReceivingMethodAndSnapshot(db, {
+					...allocationInput,
+					receivingMethodId: candidate.receivingMethodId,
+					paymentMethodId: candidate.paymentMethodId,
+					expectedAmountUnits,
+					...(input.order ? { order: input.order } : {}),
+					...(input.existingOrder
+						? { existingOrder: input.existingOrder }
+						: {}),
+				});
+				return { ...allocated, expectedAmountUnits, paymentAmount };
+			} catch (error) {
+				if (!(error instanceof ReceivingMethodUnavailableError)) throw error;
+				if (error.reason !== "collision") {
+					candidates.splice(candidates.indexOf(candidate), 1);
+					if (candidates.length === 0) throw error;
+				}
+			}
 		}
 	}
 	throw new ReceivingMethodUnavailableError();

--- a/tests/integration/receiving-method-rotation.test.ts
+++ b/tests/integration/receiving-method-rotation.test.ts
@@ -1,0 +1,98 @@
+import { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createOrderSchema } from "#/features/orders/schema";
+import { createOrder } from "#/features/orders/server/create";
+import { applyMigrations } from "./migrations";
+
+const PRIMARY_ADDRESS = "TXLAQ63Xg1NAzckPwKHvzw7CSEmLMEqcdj";
+const SECONDARY_ADDRESS = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+
+describe("receiving method rotation for equal-amount orders", () => {
+	let miniflare: Miniflare;
+	let db: D1Database;
+
+	beforeAll(async () => {
+		miniflare = new Miniflare({
+			modules: true,
+			script: "export default { fetch() { return new Response('ok') } }",
+			d1Databases: { DB: "gmpay-edge-receiving-method-rotation" },
+		});
+		db = await miniflare.getD1Database("DB");
+		await applyMigrations(db);
+		await seed(db);
+	});
+
+	afterAll(async () => miniflare.dispose());
+
+	function orderInput(externalOrderId: string) {
+		return createOrderSchema.parse({
+			externalOrderId,
+			amount: "1",
+			currency: "TRX",
+			paymentAsset: "TRX",
+			paymentNetwork: "tron",
+		});
+	}
+
+	it("spreads equal amounts across ready methods before stepping the amount", async () => {
+		await expect(
+			createOrder(db, orderInput("rotation-1"), "https://pay.example.test"),
+		).resolves.toMatchObject({
+			receivingMethodId: "method-primary",
+			receiveAddress: PRIMARY_ADDRESS,
+			paymentAmount: "1",
+		});
+		await expect(
+			createOrder(db, orderInput("rotation-2"), "https://pay.example.test"),
+		).resolves.toMatchObject({
+			receivingMethodId: "method-secondary",
+			receiveAddress: SECONDARY_ADDRESS,
+			paymentAmount: "1",
+		});
+		await expect(
+			createOrder(db, orderInput("rotation-3"), "https://pay.example.test"),
+		).resolves.toMatchObject({
+			receivingMethodId: "method-primary",
+			receiveAddress: PRIMARY_ADDRESS,
+			paymentAmount: "1.0001",
+		});
+	});
+
+	it("keeps an explicitly pinned method without rotating", async () => {
+		const input = createOrderSchema.parse({
+			externalOrderId: "rotation-pinned",
+			amount: "1",
+			currency: "TRX",
+			receivingMethodId: "method-secondary",
+		});
+		await expect(
+			createOrder(db, input, "https://pay.example.test"),
+		).resolves.toMatchObject({
+			receivingMethodId: "method-secondary",
+			receiveAddress: SECONDARY_ADDRESS,
+			paymentAmount: "1.0001",
+		});
+	});
+});
+
+async function seed(db: D1Database) {
+	await db.batch([
+		db.prepare(
+			"INSERT INTO payment_rails (code, name, kind, adapter, created_at, updated_at) VALUES ('tron', 'TRON', 'chain', 'tron', 1, 1)",
+		),
+		db.prepare(
+			"INSERT INTO payment_assets (id, rail_code, code, symbol, kind, decimals, default_confirmations, created_at, updated_at) VALUES ('asset-trx', 'tron', 'TRX', 'TRX', 'native', 6, 20, 1, 1)",
+		),
+		db.prepare(
+			"INSERT INTO payment_ingresses (id, rail_code, name, type, endpoint, priority, enabled, health_status, created_at, updated_at) VALUES ('connection-tron', 'tron', 'TronGrid', 'rpc', 'https://api.trongrid.io', 1, 1, 'healthy', 1, 1)",
+		),
+		db.prepare(
+			`INSERT INTO receiving_methods (id, name, rail_code, target_type, target_value, normalized_target_value, sort_order, enabled, created_at, updated_at)
+			 VALUES ('method-primary', 'Primary TRX', 'tron', 'address', '${PRIMARY_ADDRESS}', '${PRIMARY_ADDRESS}', 1, 1, 1, 1),
+			 ('method-secondary', 'Secondary TRX', 'tron', 'address', '${SECONDARY_ADDRESS}', '${SECONDARY_ADDRESS}', 2, 1, 1, 1)`,
+		),
+		db.prepare(
+			"INSERT INTO exchange_rates (id, category, base, quote, raw_rate, rate, source, adjustment_bps, observed_at, expires_at, created_at, updated_at) VALUES ('rate-usd-trx', 'fiat', 'USD', 'TRX', '1', '1', 'manual', 0, 900, 9999999999999, 1, 1)",
+		),
+	]);
+}


### PR DESCRIPTION
When an order targets an asset and network without pinning a receiving method, allocation now tries every ready method at the requested amount before stepping the amount up, so concurrent equal-amount orders spread across configured addresses instead of stacking increments on the first one. Explicitly pinned methods and checkout selection keep their single-method behavior.