### PR TITLE
fix(cloudflare): avoid duplicate one-click builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,11 @@ before accepting production payments.
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/GMWalletApp/gmpay-edge)
 
 The guided flow requires a public source repository. It provisions the bindings
-declared in `wrangler.jsonc`, applies D1 migrations, and builds the Worker. Use
-`bun run build` as the Build command and `wrangler deploy` as the Deploy command.
-When deployment finishes, open `/install` on the Worker URL to initialize the
-instance.
+declared in `wrangler.jsonc`, applies D1 migrations, and builds the Worker. Keep
+the auto-detected `bun run build` Build command and `bun run deploy` Deploy
+command. Workers Builds reuses the generated artifact instead of rebuilding it
+during deployment. When deployment finishes, open `/install` on the Worker URL
+to initialize the instance.
 
 ### Wrangler CLI
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -106,7 +106,7 @@ GMPay Edge 以单个 Cloudflare Worker 部署，并使用 D1、KV、私有 R2、
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/GMWalletApp/gmpay-edge)
 
-引导流程要求源仓库公开。它会配置 `wrangler.jsonc` 中声明的绑定、执行 D1 migration 并构建 Worker。Build command 使用 `bun run build`，Deploy command 使用 `wrangler deploy`。部署完成后访问 Worker 地址的 `/install` 初始化实例。
+引导流程要求源仓库公开。它会配置 `wrangler.jsonc` 中声明的绑定、执行 D1 migration 并构建 Worker。请保留自动检测的 Build command `bun run build` 和 Deploy command `bun run deploy`；Workers Builds 会在部署阶段复用已经生成的产物，不会重复构建。部署完成后访问 Worker 地址的 `/install` 初始化实例。
 
 ### Wrangler CLI
 

--- a/docs/en-US/DEPLOYMENT.md
+++ b/docs/en-US/DEPLOYMENT.md
@@ -15,10 +15,11 @@ EPay boundary adapter.
 
 The guided flow forks the repository and configures Workers Builds. The source
 repository must be public when the button is used. Configure `bun run build` as
-the Build command and `wrangler deploy` as the Deploy command. The build command
+the Build command and the auto-detected `bun run deploy` as the Deploy command. The build command
 reuses exact named D1, KV, R2, and Queue resources, creates only missing ones,
 applies the D1 baseline, and compiles a Vite artifact containing the resolved
-D1/KV IDs. The portable source `wrangler.jsonc` is never rewritten.
+D1/KV IDs. The deploy lifecycle skips rebuilding inside Workers Builds and uploads
+that generated artifact. The portable source `wrangler.jsonc` is never rewritten.
 When deployment finishes, open `/install` on the Worker URL.
 
 ### Wrangler CLI

--- a/docs/zh-CN/DEPLOYMENT.md
+++ b/docs/zh-CN/DEPLOYMENT.md
@@ -12,7 +12,7 @@
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/GMWalletApp/gmpay-edge)
 
-引导流程会复刻仓库并配置 Workers Builds，使用按钮时源仓库必须公开。Build command 配置为 `bun run build`，Deploy command 配置为 `wrangler deploy`。构建命令会精确复用同名 D1、KV、R2 和 Queue，只创建缺失资源；应用 D1 基线后，生成包含已解析 D1/KV ID 的 Vite 产物，整个过程不改写可移植的源码 `wrangler.jsonc`。部署完成后访问 Worker 地址的 `/install`。
+引导流程会复刻仓库并配置 Workers Builds，使用按钮时源仓库必须公开。Build command 配置为 `bun run build`，Deploy command 使用自动检测的 `bun run deploy`。构建命令会精确复用同名 D1、KV、R2 和 Queue，只创建缺失资源；应用 D1 基线后，生成包含已解析 D1/KV ID 的 Vite 产物。部署生命周期在 Workers Builds 中不会重复构建，只上传该产物；整个过程不改写可移植的源码 `wrangler.jsonc`。部署完成后访问 Worker 地址的 `/install`。
 
 ### Wrangler CLI
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "start:bun": "bun .output/server/index.mjs",
     "bundle:report": "bun run scripts/bundle-report.ts",
     "preview": "vite preview",
-    "predeploy": "bun run scripts/build.ts --remote",
+    "predeploy": "bun run scripts/build.ts --remote --skip-workers-ci",
     "deploy": "wrangler deploy",
     "cf-typegen": "wrangler types",
     "commitlint": "commitlint",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -263,7 +263,16 @@ async function buildForWorkers(): Promise<void> {
 	await bindGeneratedStorage(databaseId, cacheId);
 }
 
-if (process.argv.includes("--remote") || process.env.WORKERS_CI === "1") {
+const skipWorkersCiPredeploy =
+	process.argv.includes("--skip-workers-ci") && process.env.WORKERS_CI === "1";
+
+if (skipWorkersCiPredeploy) {
+	// Workers Builds already ran the build script before its auto-detected
+	// `bun run deploy` command invokes this predeploy lifecycle hook.
+} else if (
+	process.argv.includes("--remote") ||
+	process.env.WORKERS_CI === "1"
+) {
 	await buildForWorkers();
 } else {
 	await run("vite", ["build"]);

--- a/tests/unit/cloudflare-config.test.ts
+++ b/tests/unit/cloudflare-config.test.ts
@@ -55,6 +55,19 @@ describe("Cloudflare deployment contract", () => {
 			join(fixtureDirectory, "wrangler.jsonc"),
 			await readFile(new URL("../../wrangler.jsonc", import.meta.url), "utf8"),
 		);
+		const packageJson = JSON.parse(
+			await readFile(new URL("../../package.json", import.meta.url), "utf8"),
+		) as { scripts?: Record<string, string> };
+		await writeFile(
+			join(fixtureDirectory, "package.json"),
+			JSON.stringify({
+				type: "module",
+				scripts: {
+					predeploy: packageJson.scripts?.predeploy,
+					deploy: packageJson.scripts?.deploy,
+				},
+			}),
+		);
 		const fakeCommand = `#!/usr/bin/env bun
 import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
@@ -76,7 +89,7 @@ if (tool === "wrangler" && args[0] === "kv" && args[1] === "namespace" && args[2
 	console.log(JSON.stringify(exists ? [{ id: "cache-id", title: "gmpay-edge-cache" }] : []));
 }
 if (tool === "wrangler" && args[0] === "kv" && args[1] === "namespace" && args[2] === "create") writeFileSync(cacheMarker, "");
-if (tool === "vite" && process.env.WORKERS_CI === "1") {
+if (tool === "vite" && args[0] === "build") {
 	mkdirSync(join(process.cwd(), "dist/server"), { recursive: true });
 	writeFileSync(join(process.cwd(), "dist/server/wrangler.json"), JSON.stringify({ d1_databases: [{ binding: "DB" }], kv_namespaces: [{ binding: "CACHE" }] }));
 }
@@ -140,7 +153,7 @@ if (tool === "vite" && process.env.WORKERS_CI === "1") {
 		) as { scripts?: Record<string, string> };
 		expect(packageJson.scripts?.build).toBe("bun run scripts/build.ts");
 		expect(packageJson.scripts?.predeploy).toBe(
-			"bun run scripts/build.ts --remote",
+			"bun run scripts/build.ts --remote --skip-workers-ci",
 		);
 		expect(packageJson.scripts?.deploy).toBe("wrangler deploy");
 		expect(packageJson.scripts?.["db:migrate:remote"]).toBe(
@@ -218,6 +231,33 @@ if (tool === "vite" && process.env.WORKERS_CI === "1") {
 		]);
 	});
 
+	it("skips the redundant predeploy build in Workers Builds", async () => {
+		expect(await runDeployFixture(fixtureDirectory, { WORKERS_CI: "1" })).toBe(
+			0,
+		);
+		expect(await readCommands(fixtureDirectory)).toEqual([
+			{ tool: "wrangler", args: ["deploy"] },
+		]);
+	});
+
+	it("keeps remote preparation in a local package deployment", async () => {
+		expect(await runDeployFixture(fixtureDirectory)).toBe(0);
+		const commands = await readCommands(fixtureDirectory);
+		expect(
+			commands.some(
+				({ tool, args }) =>
+					tool === "wrangler" &&
+					args.join(" ") === "d1 migrations apply gmpay-edge --remote",
+			),
+		).toBe(true);
+		expect(
+			commands.some(
+				({ tool, args }) => tool === "vite" && args.join(" ") === "build",
+			),
+		).toBe(true);
+		expect(commands.at(-1)).toEqual({ tool: "wrangler", args: ["deploy"] });
+	});
+
 	it("keeps TanStack Start on its streaming SSR handler", async () => {
 		const source = await readFile(
 			new URL("../../src/server-entry.ts", import.meta.url),
@@ -233,8 +273,33 @@ type Command = { tool: string; args: string[] };
 async function runFixture(
 	directory: string,
 	environment: Record<string, string> = {},
+	arguments_: string[] = [],
 ) {
-	const child = spawn("bun", [join(directory, "scripts/build.ts")], {
+	const child = spawn(
+		"bun",
+		[join(directory, "scripts/build.ts"), ...arguments_],
+		{
+			cwd: directory,
+			env: {
+				...process.env,
+				...environment,
+				COMMAND_LOG: join(directory, "commands.ndjson"),
+				PATH: `${join(directory, "bin")}:${process.env.PATH ?? ""}`,
+			},
+			stdio: "ignore",
+		},
+	);
+	return new Promise<number>((resolve, reject) => {
+		child.once("error", reject);
+		child.once("close", (code) => resolve(code ?? 1));
+	});
+}
+
+async function runDeployFixture(
+	directory: string,
+	environment: Record<string, string> = {},
+) {
+	const child = spawn("bun", ["run", "deploy"], {
 		cwd: directory,
 		env: {
 			...process.env,


### PR DESCRIPTION
## Summary

- preserve the Deploy to Cloudflare button's auto-detected `bun run build` and `bun run deploy` commands
- skip the redundant `predeploy` rebuild only inside Workers Builds
- keep local `bun run deploy` behavior unchanged
- document the actual one-click command flow in both READMEs and deployment checklists

## Why

Deploy to Cloudflare derives its commands from `package.json`. Because this repository defines both scripts, the button correctly pre-populates `bun run build` and `bun run deploy`. Bun then invokes `predeploy`, which previously repeated remote resource discovery, D1 migrations, and the complete Vite build after Workers Builds had already run the build step.

The new `--skip-workers-ci` guard makes that lifecycle hook a no-op only when `WORKERS_CI=1`; direct CLI deployment still performs the full remote preparation before Wrangler deploys.

## Validation

- `vitest run tests/unit/cloudflare-config.test.ts` (8 passed, including real `bun run deploy` lifecycle coverage)
- `tsc --noEmit`
- `biome check` (701 files)
- `git diff --check`